### PR TITLE
Add JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK flag

### DIFF
--- a/src/limits.rs
+++ b/src/limits.rs
@@ -3,7 +3,7 @@ use windows::Win32::System::{
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_AFFINITY,
         JOB_OBJECT_LIMIT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
         JOB_OBJECT_LIMIT_PRIORITY_CLASS, JOB_OBJECT_LIMIT_SCHEDULING_CLASS,
-        JOB_OBJECT_LIMIT_WORKINGSET,
+        JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_WORKINGSET,
     },
     Threading::{
         ABOVE_NORMAL_PRIORITY_CLASS, BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS,
@@ -66,6 +66,14 @@ impl ExtendedLimitInfo {
     /// this flag, the child process is not associated with the job.
     pub fn limit_breakaway_ok(&mut self) -> &mut Self {
         self.0.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+
+        self
+    }
+
+    /// Allows any process associated with the job to create child processes that
+    /// are not associated with the job.
+    pub fn limit_silent_breakaway_ok(&mut self) -> &mut Self {
+        self.0.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
 
         self
     }


### PR DESCRIPTION
Add the [SILENT_BREAKAWAY_OK](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information) flag as an option in the `win32job` crate. This seems to differ from the BREAKAWAY_OK flag in that child process are automatically not associated with the job object, instead of child processes needing to opt out of being associated with the job object.

I'm not entirely sure if this is what we want yet, but I'd like to experiment. Checking it in makes it easier for me to send branches to other folks on the team to test with.